### PR TITLE
Enable other STM32 architectures.

### DIFF
--- a/src/ADCTouchSensor.h
+++ b/src/ADCTouchSensor.h
@@ -24,6 +24,9 @@
 #elif defined(ARDUINO_ARCH_AVR)
 # define ADCTOUCH_DEFAULT_DELAY 0
 # define ADCTOUCH_DIVIDER       1
+#elif defined(ARDUINO_ARCH_STM32)
+# define ADCTOUCH_DEFAULT_DELAY 0
+# define ADCTOUCH_DIVIDER       4
 #endif
 
 class ADCTouchSensor


### PR DESCRIPTION
Hi @arpruss!

Following up on the issue #9, here is a proposition that might be good for other ADCTouchSensor users who would want to try the STM32duino (it's supported by ST so they have a lot of new architectures).

There is no default option for `ADCTOUCH_DIVIDER`, so another even more inclusive option could be to use `#else` instead of my proposed `#elif defined(ARDUINO_ARCH_STM32)` (see [here](https://github.com/arpruss/ADCTouchSensor/commit/43cefbb16d97dacdf034805f8708c0b31867b37b#diff-e06201c2cf426c2cd809e71ffb8aedd34071db2cde9011c072893f09e1cbcb19R27)).

Let me know if you prefer this 2nd option?

...or if there is anything I could do to make this pull request better?

Thanks again for  this great lib!
Cedric :)

---

PS: It seems that Roger Clark suggests to use the [stm32duino core](https://github.com/stm32duino/Arduino_Core_STM32/) now:
https://github.com/rogerclarkmelbourne/Arduino_STM32#background--support
